### PR TITLE
Fix implode()

### DIFF
--- a/CoinCornerCheckout.php
+++ b/CoinCornerCheckout.php
@@ -260,7 +260,7 @@ function CoinCornerCheckout()
                 'Nonce' => $nonce,
                 'InvoiceAmount' => $amount,
                 'NotificationURL' => $this->notify_url,
-                'ItemDescription' => implode($description, ', '),
+                'ItemDescription' => implode(', ',$description),
                 'ItemCode' => '',
                 'SuccessRedirectURL' => $ReturnUrl,
                 'FailRedirectURL' => $FailURL,


### PR DESCRIPTION
Change should be backwards-compatible. Prior to PHP 7.4 the arguments to implode() could be in any order, now they have a set order and we lost the coin-flip.